### PR TITLE
Update stack to 2.3.1

### DIFF
--- a/8.10.1/bionic/Dockerfile
+++ b/8.10.1/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/bionic/slim/Dockerfile
+++ b/8.10.1/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/buster/Dockerfile
+++ b/8.10.1/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/buster/slim/Dockerfile
+++ b/8.10.1/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/stretch/Dockerfile
+++ b/8.10.1/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/stretch/slim/Dockerfile
+++ b/8.10.1/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/xenial/Dockerfile
+++ b/8.10.1/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10.1/xenial/slim/Dockerfile
+++ b/8.10.1/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/bionic/Dockerfile
+++ b/8.10/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/bionic/slim/Dockerfile
+++ b/8.10/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/buster/Dockerfile
+++ b/8.10/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/buster/slim/Dockerfile
+++ b/8.10/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/stretch/Dockerfile
+++ b/8.10/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/stretch/slim/Dockerfile
+++ b/8.10/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/xenial/Dockerfile
+++ b/8.10/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         ghc-8.10.1-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.10/xenial/slim/Dockerfile
+++ b/8.10/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.10.1 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/bionic/Dockerfile
+++ b/8.2.2/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/bionic/slim/Dockerfile
+++ b/8.2.2/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/buster/Dockerfile
+++ b/8.2.2/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/buster/slim/Dockerfile
+++ b/8.2.2/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/stretch/Dockerfile
+++ b/8.2.2/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/stretch/slim/Dockerfile
+++ b/8.2.2/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/xenial/Dockerfile
+++ b/8.2.2/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2.2/xenial/slim/Dockerfile
+++ b/8.2.2/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/bionic/Dockerfile
+++ b/8.2/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/bionic/slim/Dockerfile
+++ b/8.2/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/buster/Dockerfile
+++ b/8.2/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/buster/slim/Dockerfile
+++ b/8.2/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/stretch/Dockerfile
+++ b/8.2/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/stretch/slim/Dockerfile
+++ b/8.2/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/xenial/Dockerfile
+++ b/8.2/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         ghc-8.2.2-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.2/xenial/slim/Dockerfile
+++ b/8.2/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.2.2 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/bionic/Dockerfile
+++ b/8.4.4/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/bionic/slim/Dockerfile
+++ b/8.4.4/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/buster/Dockerfile
+++ b/8.4.4/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/buster/slim/Dockerfile
+++ b/8.4.4/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/stretch/Dockerfile
+++ b/8.4.4/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/stretch/slim/Dockerfile
+++ b/8.4.4/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/xenial/Dockerfile
+++ b/8.4.4/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4.4/xenial/slim/Dockerfile
+++ b/8.4.4/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/bionic/Dockerfile
+++ b/8.4/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/bionic/slim/Dockerfile
+++ b/8.4/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/buster/Dockerfile
+++ b/8.4/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/buster/slim/Dockerfile
+++ b/8.4/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/stretch/Dockerfile
+++ b/8.4/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/stretch/slim/Dockerfile
+++ b/8.4/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/xenial/Dockerfile
+++ b/8.4/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         ghc-8.4.4-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.4/xenial/slim/Dockerfile
+++ b/8.4/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.4.4 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/bionic/Dockerfile
+++ b/8.6.5/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/bionic/slim/Dockerfile
+++ b/8.6.5/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/buster/Dockerfile
+++ b/8.6.5/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/buster/slim/Dockerfile
+++ b/8.6.5/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/stretch/Dockerfile
+++ b/8.6.5/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/stretch/slim/Dockerfile
+++ b/8.6.5/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/xenial/Dockerfile
+++ b/8.6.5/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6.5/xenial/slim/Dockerfile
+++ b/8.6.5/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/bionic/Dockerfile
+++ b/8.6/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/bionic/slim/Dockerfile
+++ b/8.6/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/buster/Dockerfile
+++ b/8.6/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/buster/slim/Dockerfile
+++ b/8.6/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/stretch/Dockerfile
+++ b/8.6/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/stretch/slim/Dockerfile
+++ b/8.6/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/xenial/Dockerfile
+++ b/8.6/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         ghc-8.6.5-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.6/xenial/slim/Dockerfile
+++ b/8.6/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.6.5 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/bionic/Dockerfile
+++ b/8.8.3/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/bionic/slim/Dockerfile
+++ b/8.8.3/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/buster/Dockerfile
+++ b/8.8.3/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/buster/slim/Dockerfile
+++ b/8.8.3/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/stretch/Dockerfile
+++ b/8.8.3/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/stretch/slim/Dockerfile
+++ b/8.8.3/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/xenial/Dockerfile
+++ b/8.8.3/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8.3/xenial/slim/Dockerfile
+++ b/8.8.3/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/bionic/Dockerfile
+++ b/8.8/bionic/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/bionic/slim/Dockerfile
+++ b/8.8/bionic/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/buster/Dockerfile
+++ b/8.8/buster/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/buster/slim/Dockerfile
+++ b/8.8/buster/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/stretch/Dockerfile
+++ b/8.8/stretch/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/stretch/slim/Dockerfile
+++ b/8.8/stretch/slim/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/xenial/Dockerfile
+++ b/8.8/xenial/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         ghc-8.8.3-prof libtinfo-dev && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/8.8/xenial/slim/Dockerfile
+++ b/8.8/xenial/slim/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends ghc-8.8.3 cabal-install-3.2 \
         zlib1g-dev libtinfo-dev libsqlite3-dev g++ netbase xz-utils make && \
-    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.1.3/stack-2.1.3-linux-x86_64.tar.gz -o stack.tar.gz && \
-    echo "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673  stack.tar.gz" | sha256sum -c - && \
+    curl -fSL https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz -o stack.tar.gz && \
+    echo "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d  stack.tar.gz" | sha256sum -c - && \
     tar -xf stack.tar.gz -C /usr/local/bin --strip-components=1 && \
     /usr/local/bin/stack config set system-ghc --global true && \
     /usr/local/bin/stack config set install-ghc --global false && \

--- a/generate.hs
+++ b/generate.hs
@@ -44,9 +44,9 @@ imageDefs = Images
         , pGhcVersion   = gv
         , pSlim         = slim
         , pStack        = gv >= Version [8,2] -- I don't know what stack supports
-        , pStackVersion = Version [2,1,3]
+        , pStackVersion = Version [2,3,1]
         -- See stack-shasum.sh
-        , pStackSha256  = "c724b207831fe5f06b087bac7e01d33e61a1c9cad6be0468f9c117d383ec5673"
+        , pStackSha256  = "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d"
         , pIsDebian     = dist `elem` [Stretch, Buster]
         }
       where

--- a/stack-shasum.sh
+++ b/stack-shasum.sh
@@ -7,7 +7,7 @@
 # gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys 2C6A674E85EE3FB896AFC9B965101FF31C5C154D
 #
 
-STACKVER=2.1.3
+STACKVER=2.3.1
 
 curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACKVER}/stack-${STACKVER}-linux-x86_64.tar.gz -o stack.tar.gz && \
 curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACKVER}/stack-${STACKVER}-linux-x86_64.tar.gz.asc -o stack.tar.gz.asc && \
@@ -15,4 +15,3 @@ curl -fSL https://github.com/commercialhaskell/stack/releases/download/v${STACKV
 gpg --batch --trusted-key 0x575159689BEFB442 --verify stack.tar.gz.asc stack.tar.gz
 
 sha256sum stack.tar.gz
- 


### PR DESCRIPTION
https://github.com/commercialhaskell/stack/releases/tag/v2.3.1

* Update stack to 2.3.1
* Include stack in images 7.8 -> 8.10 which is the [officially supported range for stack 2.3.1](https://github.com/commercialhaskell/stack/blob/v2.3.1/src/Stack/Setup.hs#L457-L476).

I ran `make build` and all the images built with these changes.